### PR TITLE
Implement `PlanetsLib.set_default_import_location(item_name, planet)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ contribute via pull requests on
     * A new row is available in Factoriopedia for moons.
 * `PlanetLib:borrow_music(source_planet, target_planet)` clone music tracks from an existing planet.
 * New surface condition 'temperature' with default values as below.
+* `PlanetLib:set_default_import_location(item_name, planet)
 
 ## Base game planet temperatures
 

--- a/lib/planet.lua
+++ b/lib/planet.lua
@@ -105,4 +105,19 @@ function Public.borrow_music(source_planet, target_planet)
     end
 end
 
+--- This function sets `default_import_location` based on an item name and planet.
+--- `default_import_location` is used by the space platform GUI to
+--- define the default planet where an item will be imported from.
+function Public.set_default_import_location(item_name, planet)
+    for item_prototype in pairs(defines.prototypes.item) do
+        local item = (data.raw[item_prototype] or {})[item_name]
+        if item then
+            item.default_import_location = planet
+            return
+        end
+    end
+
+    error("PlanetsLib:set_default_import_location() - Item not found: " .. item_name, 2)
+end
+
 return Public


### PR DESCRIPTION
This PR adds a new function into planetslib: `PlanetsLib.set_default_import_location(item_name, planet)`

This function sets default import locations from an item_name.
These import locations will be used when selecting filters for the space platform request GUI.

Example usage:

```lua
PlanetsLib.set_default_import_location("maraxsis-big-cliff-explosives", "nauvis")
PlanetsLib.set_default_import_location("sp-spidertron-dock", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-diesel-submarine", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-nuclear-submarine", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-hydro-plant", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-fishing-tower", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-sonar", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-pressure-dome", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-coral", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-limestone", "maraxsis")
PlanetsLib.set_default_import_location("sand", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-glass-panes", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-fish-food", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-tropical-fish", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-microplastics", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-wyrm-specimen", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-wyrm-confinement-cell", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-super-sealant-substance", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-salt", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-salt-filter", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-saturated-salt-filter", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-salted-fish", "nauvis")
PlanetsLib.set_default_import_location("maraxsis-salted-tropical-fish", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-defluxed-bioflux", "gleba")
PlanetsLib.set_default_import_location("maraxsis-salted-science", "gleba")
PlanetsLib.set_default_import_location("hydraulic-science-pack", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-atmosphere-barrel", "nauvis")
PlanetsLib.set_default_import_location("maraxsis-liquid-atmosphere-barrel", "aquilo")
PlanetsLib.set_default_import_location("maraxsis-brackish-water-barrel", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-saline-water-barrel", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-oxygen-barrel", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-hydrogen-barrel", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-fat-man", "nauvis")
PlanetsLib.set_default_import_location("maraxsis-abyssal-diving-gear", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-salt-reactor", "maraxsis")
PlanetsLib.set_default_import_location("maraxsis-conduit", "maraxsis")
```