### PR TITLE
Fix Dependency Loop crash with MT-lib

### DIFF
--- a/info.json
+++ b/info.json
@@ -10,8 +10,7 @@
     "base >= 2.0.0",
     "space-age >= 2.0.0",
     "? Tiered-Solar-System",
-    "(?) Surfaces-Have-Temperature",
-    "(?) MT-lib-ex"
+    "(?) Surfaces-Have-Temperature"
   ],
   "package": {
     "sync_portal_details": true,


### PR DESCRIPTION
Hello, this should fix the mod dependency loop crash with MT-lib. Another crash appeared which I should have fixed on my end which was related to my planet load order function and it was essentially causing the game to continually start up.