### PR TITLE
Better Planet Table Sanity-Checking

### DIFF
--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -1,30 +1,29 @@
 local orbits = require("lib.orbits")
-
 -- Force-set the position of planets and moons, in case other mods moved them:
-for _, p in pairs(data.raw.planet) do
-	if p.orbit then
-		local distance, orientation = orbits.get_absolute_polar_position_from_orbit(p.orbit)
-		p.distance = distance
-		p.orientation = orientation
-	end
+local planets_with_orbits = orbits.get_planets_with_orbits(data.raw.planet)
+for _, p in pairs(planets_with_orbits) do
+    local distance, orientation = orbits.get_absolute_polar_position_from_orbit(p.orbit)
+    p.distance = distance
+    p.orientation = orientation
 end
-for _, p in pairs(data.raw["space-location"]) do
-	if p.orbit then
-		local distance, orientation = orbits.get_absolute_polar_position_from_orbit(p.orbit)
-		p.distance = distance
-		p.orientation = orientation
-	end
+
+local spaceLocs = orbits.get_planets_with_orbits(data.raw["space-location"])
+for _, p in pairs(spaceLocs) do
+    local distance, orientation = orbits.get_absolute_polar_position_from_orbit(p.orbit)
+    p.distance = distance
+    p.orientation = orientation
 end
 
 require("prototypes.override-final.starmap")
 
-for _, p in pairs(data.raw.planet) do
-	if p.sprite_only then
-		data.raw.planet[p.name] = nil
-	end
+for _, p in pairs(planets_with_orbits) do
+    if p.sprite_only then
+        data.raw.planet[p.name] = nil
+    end
 end
-for _, p in pairs(data.raw["space-location"]) do
-	if p.sprite_only then
-		data.raw["space-location"][p.name] = nil
-	end
+
+for _, p in pairs(spaceLocs) do
+    if p.sprite_only then
+        data.raw["space-location"][p.name] = nil
+    end
 end

--- a/lib/orbits.lua
+++ b/lib/orbits.lua
@@ -1,5 +1,17 @@
 local Public = {}
 
+function Public.get_planets_with_orbits(planets)
+    local planets_with_orbits = {}
+    
+    for _, planet in pairs(planets) do
+        if planet.orbit then
+            table.insert(planets_with_orbits, planet)
+        end
+    end
+    
+    return planets_with_orbits
+end
+
 function Public.get_absolute_polar_position_from_orbit(orbit)
 	local parent = orbit.parent
 

--- a/prototypes/override-final/starmap.lua
+++ b/prototypes/override-final/starmap.lua
@@ -57,10 +57,12 @@ function Public.update_starmap_from_sprite(sprite, x, y)
 	table.insert(starmap_layers, sprite_copy)
 end
 
-for _, planet in pairs(data.raw["planet"]) do
+local planets = orbits.get_planets_with_orbits(data.raw["planet"])
+for _, planet in pairs(planets) do
 	Public.update_starmap_layers(planet)
 end
-for _, space_location in pairs(data.raw["space-location"]) do
+local spaceLocs = orbits.get_planets_with_orbits(data.raw["space-location"])
+for _, space_location in pairs(spaceLocs) do
 	Public.update_starmap_layers(space_location)
 end
 


### PR DESCRIPTION
This mod kept throwing errors when iterating over planets/space locations without an orbit, I have a heavily modded list so who knows what mod caused it, thus I thought Id help out and provide a fix directly:

- Created a single planet collection function that contains filtering, to reduce filtering within each function that uses a planet without an orbit. 
- Fixed starmap.lua not checking against orbitless planets.

Tell me if function or variable names should be changed.