### PR TITLE
Locale change([Planet: {}] to [Body: {}]

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ The following conditions are hidden but always enabled.
 
 ## Further notes for contributors
 
-* Please TEST YOUR CHANGES. I would like release versions with minimal testing of new features on my behalf. You might break a lot of games if you don't do this.
-* I'm currently publishing releases of this mod manually. In your pull requests, I ask you list your changes in changelog.txt to be included in the next release. Please also update README.md adding sections for your new functionality (even with only 'Documentation pending.') and adding yourself to the contributors list above.
-* Feel free to make use of the file `todo.md`.
-
+* Please TEST YOUR CHANGES. thesixthroc would like to release versions with minimal testing of new features on their part. You might break a lot of games if you don't do this.
+* We're currently publishing releases of this mod manually. In your pull requests, please list your changes in changelog.txt to be included in the next release. Please also update README.md to add sections for your new functionality (even with only 'Documentation pending.') and add yourself to the contributors list.
+* Feel free to use the file `todo.md`.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,5 @@
 ---------------------------------------------------------------------------------------------------
-Version: 1.1.21
+Version: 1.1.22
 Date: ????
   Features:
     - PlanetsLib.exact_value(property,value):  Returns a surface condition locking the acceptable range of values to one.
@@ -12,6 +12,11 @@ Date: ????
     - Added set of description templates to standardize how the relationships between planets are moons are described.
     - Replaced instances of word "Planet" with "Body" in "following-text-planet" locale key and a few other keys.
 
+---------------------------------------------------------------------------------------------------
+Version: 1.1.21
+Date: 2025-01-13
+  Bugfixes:
+    - Support for mods that delete all space locations.
 ---------------------------------------------------------------------------------------------------
 Version: 1.1.20
 Date: 2025-01-13

--- a/changelog.txt
+++ b/changelog.txt
@@ -10,6 +10,7 @@ Date: ????
     - Added documentation for enabling optional surface conditions, in addition to everything else in this update.
   Locale:
     - Added set of description templates to standardize how the relationships between planets are moons are described.
+    - Replaced instances of word "Planet" with "Body" in "following-text-planet" locale key and a few other keys.
 
 ---------------------------------------------------------------------------------------------------
 Version: 1.1.20

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
     "name": "PlanetsLib",
-    "version": "1.1.21",
+    "version": "1.1.22",
     "factorio_version": "2.0",
     "title": "PlanetsLib",
     "author": "thesixthroc",

--- a/locale/en/core.cfg
+++ b/locale/en/core.cfg
@@ -4,3 +4,13 @@ planets=Space locations
 landing-on-planet-tooltip=You will drop to __1__ when __2__ is in orbit overhead.
 land-on-planet-tooltip=Choose a space location to drop to when __1__ is in orbit overhead.
 select-a-planet=Select space location
+
+[gui-text-tags]
+following-text-planet= [Body: __1__]
+
+[command-help]
+matching-planets-list=Matching bodies: __1__
+planets-list=Bodies: __1__
+
+[gui-map-generator]
+appears-on-description=The planets that this resource is generated on.

--- a/prototypes/override-final/starmap.lua
+++ b/prototypes/override-final/starmap.lua
@@ -157,6 +157,8 @@ for _, location in pairs(ordered_locations) do
 	end
 end
 
-data.raw["utility-sprites"]["default"].starmap_star = { layers = starmap_layers }
+if #starmap_layers > 0 then
+	data.raw["utility-sprites"]["default"].starmap_star = { layers = starmap_layers }
+end
 
 return Public


### PR DESCRIPTION
Assuming that my [previous pull request](https://github.com/danielmartin0/PlanetsLib/pull/13) is approved, I have one minor locale change to make that might be controversial, which is to replace the use of "Planet" in gui text tags with "Body", as well as in a few other locale strings. 

After experimenting with adding tooltips to planet descriptions listing all of the moons orbiting the planet, I became annoyed by how moons are referred to as planets. Body is a more inclusive word than planet, and since a large part of this mod involves making moons easier to make, we should do more to use language inclusive of both planets and moons.

 
![image](https://github.com/user-attachments/assets/b1c4c74c-fc90-45a8-9eb4-734057033664)
