### PR TITLE
Fix doc errors for borrow_music and set_default_import_location

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Planet prototypes and space location prototypes can be defined using the followi
 
 ### Other planet helpers
 
-* `PlanetsLib:borrow_music(source_planet, target_planet)` - Clones music tracks from an existing planet to a new one.
-* `PlanetsLib:set_default_import_location(item_name, planet)` - Sets the default import location for an item on a planet.
+* `PlanetsLib.borrow_music(source_planet, target_planet)` - Clones music tracks from an existing planet to a new one.
+* `PlanetsLib.set_default_import_location(item_name, planet)` - Sets the default import location for an item on a planet.
 
 ### Planet Cargo Drops technology
 


### PR DESCRIPTION
I got an error while trying to use `borrow_music`. I noticed that the colon notation for the call is not correct because `api.lua` defines it with a dot. I tested both functions.