### PR TITLE
Orbit sprite generator documentation, and simplification of orbit generator function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 *.zip
 prepublish.js
+*.pyc

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Planet prototypes and space location prototypes can be defined using the followi
         * `parent` — Object containing `name` and `type` fields, corresponding to a parent at `data.raw[type][name]`. Planets in the original solar system should have an orbit with `type = "space-location"` and `name = "star"`.
         * `distance` — Number: orbital distance from parent
         * `orientation` — Number: orbital angle from parent (0-1). Note that orientation is absolute, not relative to the parent's orientation.
-        * `sprite` — Object: Sprite for the orbit, centered on its parent
-            * `lib/orbit_graphic_generator.py` contains a Python script that generates orbit sprites. `generate_orbit(distance, output_file, mod_name)`, `distance` being the same as your orbital distance. After generating your sprite, the script will print a block of lua code that imports your sprite with proper scaling. Orbit sprites should be scaled at 0.25 to ensure that no pixels are visible, even on 4K displays.
+        * `sprite` — Object: Sprite for the orbit, centered on its parent(See "Python helper scripts")
     * `sprite_only` — Boolean (optional): If true, this prototype will be removed in `data-final-fixes` and replaced by its sprites on the starmap (unless neither `starmap_icon`, `starmap_icons` nor an orbit sprite are defined, in which case nothing will show).
         * This is useful for constructing stars and other locations that should not have a space platform 'docking ring'.
     * Other valid `planet` or `space-location` prototype fields
@@ -77,3 +76,7 @@ PlanetsLib includes a wide variety of surface conditions, all of which are eithe
 ### Other helper functions
 
 * `PlanetsLib.set_default_import_location(item_name, planet)` - Sets the default import location for an item on a planet.
+
+### Python helper scripts
+
+* `lib/orbit_graphic_generator.py`: contains a Python script that generates orbit sprites. `generate_orbit(distance, output_file, mod_name)`, `distance` being the same as your orbital distance. After generating your sprite, the script will print a block of lua code that imports your sprite with proper scaling. Orbit sprites should be scaled at 0.25 to ensure that no pixels are visible, even on 4K displays.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Planet prototypes and space location prototypes can be defined using the followi
         * `distance` — Number: orbital distance from parent
         * `orientation` — Number: orbital angle from parent (0-1). Note that orientation is absolute, not relative to the parent's orientation.
         * `sprite` — Object: Sprite for the orbit, centered on its parent
+            * `lib/orbit_graphic_generator.py` contains a Python script that generates orbit sprites. `generate_orbit(distance, output_file, mod_name)`, `distance` being the same as your orbital distance. After generating your sprite, the script will print a block of lua code that imports your sprite with proper scaling. Orbit sprites should be scaled at 0.25 to ensure that no pixels are visible, even on 4K displays.
     * `sprite_only` — Boolean (optional): If true, this prototype will be removed in `data-final-fixes` and replaced by its sprites on the starmap (unless neither `starmap_icon`, `starmap_icons` nor an orbit sprite are defined, in which case nothing will show).
         * This is useful for constructing stars and other locations that should not have a space platform 'docking ring'.
     * Other valid `planet` or `space-location` prototype fields

--- a/generate_orbit_graphics.py
+++ b/generate_orbit_graphics.py
@@ -1,4 +1,7 @@
-from lib.orbit_graphic_generator import generate_circle
+from lib.orbit_graphic_generator import generate_orbit
 
-generate_circle(radius=2240, thickness=0.5, width=1, resolution=4480, output_file="orbit-aquilo.png")
-generate_circle(radius=128, thickness=1, width=1, resolution=512, output_file="orbit-muluna.png")
+#To generate orbit sprites, use the generate_orbit function in the following format:
+#generate_orbit(distance, output_file, mod_name)
+generate_orbit(10, "orbit-vulcanus.png","PlanetsLib")
+generate_orbit(1.6, "orbit-muluna.png","planet-muluna")
+

--- a/lib/orbit_graphic_generator.py
+++ b/lib/orbit_graphic_generator.py
@@ -53,7 +53,7 @@ def generate_orbit(distance, output_file, mod_name):
     plt.close()
 
     print(f"Orbit sprite saved to {os.path.abspath(output_file)}\n")
-    print(f"Add sprite to planet orbit with following code in your planet's orbit object:\n")
+    print(f"Add this to the 'orbit' field of your planet definition:\n")
     print("""sprite = {{
         type = "sprite",
         filename = "__{}__/graphics/orbits/{}",

--- a/lib/orbit_graphic_generator.py
+++ b/lib/orbit_graphic_generator.py
@@ -5,7 +5,7 @@ import math
 
 def generate_orbit(distance, output_file, mod_name):
     """Outputs an orbit sprite for a planet based on its distance, and prints a block of lua code that imports \
-        the sprite with correct scaling and sprite siz
+        the sprite with correct scaling and sprite size. The scaling will be at 0.25, a scaling that results in sprites that are crisp on all displays.
 
     distance: The planet's distance from its parent body.
     output_file: The name of the resulting image file, with file format.

--- a/lib/orbit_graphic_generator.py
+++ b/lib/orbit_graphic_generator.py
@@ -3,7 +3,22 @@ import matplotlib.pyplot as plt
 import os
 import math
 
-def generate_circle(radius=1.0, thickness=0.1, width=1, resolution=1000, output_file="circle.png"):
+def generate_orbit(distance, output_file, mod_name):
+    """Outputs an orbit sprite for a planet based on its distance, and prints a block of lua code that imports \
+        the sprite with correct scaling and sprite siz
+
+    distance: The planet's distance from its parent body.
+    output_file: The name of the resulting image file, with file format.
+    mod_name: The internal name of your mod.
+
+    Example: generate_orbit(1.6, "orbit-muluna.png","planet-muluna")
+    """
+
+    width=1
+    resolution=512*distance/2
+    thickness = 3
+    radius=distance*64
+    resolution_old=resolution
     resolution=resolution/3.696
     if thickness <= 0 or radius <= 0:
         raise ValueError("Radius and thickness must be positive.")
@@ -29,7 +44,7 @@ def generate_circle(radius=1.0, thickness=0.1, width=1, resolution=1000, output_
 
     # Adjust plot limits and remove axes
     padding = 1
-    ax.set_xlim(-(radius + thickness  + padding), radius + thickness  + padding)
+    ax.set_xlim(-1*width*(radius + thickness  + padding), 1*width*(radius + thickness  + padding))
     ax.set_ylim(-(radius + thickness  + padding), radius + thickness  + padding)
     ax.axis('off')
 
@@ -37,6 +52,13 @@ def generate_circle(radius=1.0, thickness=0.1, width=1, resolution=1000, output_
     plt.savefig(output_file, bbox_inches="tight",pad_inches=0, dpi=resolution,transparent=True)
     plt.close()
 
-    print(f"Circle saved to {os.path.abspath(output_file)}")
+    print(f"Orbit sprite saved to {os.path.abspath(output_file)}\n")
+    print(f"Add sprite to planet orbit with following code in your planet's orbit object:\n")
+    print("""sprite = {{
+        type = "sprite",
+        filename = "__{}__/graphics/orbits/{}",
+        size = {},
+        scale = 0.25,
+      }}""".format(mod_name,output_file,math.floor(resolution_old*(1+width)/2)))
 
 


### PR DESCRIPTION
The python script that generates orbit sprites has been renamed and simplified. Orbit width has been removed, because it was not functioning as expected, and resolution has been removed to enforce a single level of crispness among orbit sprites. With this function, all orbit sprites will be scaled at 0.25 to ensure that minimal pixels are visible, even on 4K displays. The distance variable has been modified to use the same distance variable used in the planet's orbit definition.  When running `generate_orbit`, the function will now print a block of lua code that can be pasted into the planet's sprite information.



`generate_orbit(distance, output_file, mod_name)`

Here is an example output:
```
>>generate_orbit(1.6, "orbit-muluna.png","planet-muluna")
Orbit sprite saved to {file_directory}/orbit-muluna.png

Add sprite to planet orbit with following code in your planet's orbit object:

sprite = {
        type = "sprite",
        filename = "__planet-muluna__/graphics/orbits/orbit-muluna.png",
        size = 409,
        scale = 0.25,
      }
```
Documentation has been updated to reflect these changes.