### PR TITLE
Adjusted orbit sprite generator, taking into account line thickness.

### DIFF
--- a/lib/orbit_graphic_generator.py
+++ b/lib/orbit_graphic_generator.py
@@ -15,8 +15,9 @@ def generate_orbit(distance, output_file, mod_name):
     """
 
     width=1
-    resolution=512*distance/2
     thickness = 3
+    resolution=512*distance/2+thickness
+    
     radius=distance*64
     resolution_old=resolution
     resolution=resolution/3.696


### PR DESCRIPTION
For Muluna's sprite, this change increases the generated sprite from 409x409 to 412x412, which brings the resulting orbit sprite closer to crossing the planet's middle.