### PR TITLE
Add api to include and sort sciences in the different labs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,17 @@ PlanetsLib includes a variety of surface conditions, all of which are either hid
 
 * `PlanetsLib.restrict_to_planet(entity_or_recipe, planet)`: Restricts the entity or recipe prototype to a given planet by adding a special surface condition unique to that planet. This surface condition is almost invisible in the UI, with the exception of messages like "X can't be crafted on this surface. The  is too low". The planet can be passed as a name or object.
 
+#### Science tools
+
+## Labs
+
+Science packs in the vanilla lab will be ordered according to the `order` field of the science pack item so you can group science packs to show up next to each other. If the order field is missing, their name will be used. This will happen in `data-final-fixes`.
+
+
+* You can include all sciences from the vanilla lab in your own lab by setting the field `include_all_base_lab_science` to true on the lab's prototype.
+* To sort the sciences in your lab set the field `sort_sciences` to true on the lab's prototype. This is not needed (will be ignored) if you included the sciences, those will be sorted already.
+
+
 ### Other helper functions
 
 * `PlanetsLib.set_default_import_location(item_name, planet)` - Sets the default import location for an item on a planet.

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -62,3 +62,49 @@ for _, planet in pairs(planets) do
 		)
 	end
 end
+
+-- fix ordering of science packs in the vanilla lab to match the pack's order string.
+
+local lab = data.raw["lab"]["lab"]
+
+local inputs = lab.inputs
+
+
+table.sort(inputs, function (left, right)
+	local left_order = data.raw["tool"][left].order
+	local right_order = data.raw["tool"][right].order
+
+	if left_order == nil then
+		left_order = data.raw["tool"][left].name
+	end
+	if right_order == nil then
+		right_order = data.raw["tool"][right].name
+	end
+	
+    return left_order < right_order
+end)
+
+lab.inputs = inputs
+
+for index, new_lab in pairs(data.raw["lab"]) do
+
+	if  lab["include_all_lab_science"] == true then
+		new_lab.inputs = inputs
+	elseif lab["sort_sciences"] == true then
+		local local_inputs = lab.inputs
+		table.sort(local_inputs, function (left, right)
+			local left_order = data.raw["tool"][left].order
+			local right_order = data.raw["tool"][right].order
+		
+			if left_order == nil then
+				left_order = data.raw["tool"][left].name
+			end
+			if right_order == nil then
+				right_order = data.raw["tool"][right].name
+			end
+			
+			return left_order < right_order
+		end)	
+		lab.inputs = local_inputs
+	end
+end

--- a/data-final-fixes.lua
+++ b/data-final-fixes.lua
@@ -85,6 +85,8 @@ table.sort(inputs, function (left, right)
 end)
 
 lab.inputs = inputs
+-- the biolab should have all of these by default
+data.raw["lab"]["biolab"].include_all_lab_science = true
 
 for index, new_lab in pairs(data.raw["lab"]) do
 


### PR DESCRIPTION
As discussed in discord, add code to the lib to sort sciences in the different labs according to their order field to make them manageable, and also to sort the packs in those labs.

Check the readme for the instructions.