### PR TITLE
Promethium science fix

### DIFF
--- a/lib/technology.lua
+++ b/lib/technology.lua
@@ -120,9 +120,24 @@ function Public.set_science_packs_from_lab(technology, lab)
 		existing_packs[pack[1]] = true
 	end
 
-	for _, value in pairs(inputs) do
-		if not existing_packs[value] then
-			table.insert(technology.unit.ingredients, { value, 1 })
+
+	for _, value in pairs(inputs) do --For input in lab inputs
+		local to_insert = true
+		for _, effect in pairs(technology.effects) do --Check if this technology unlocks a science pack. If yes, don't make this technology require that pack.
+			
+			if (effect.type == "unlock-recipe" and effect.recipe == value) then
+				to_insert = false
+				break
+			end	
+		end
+		for key,pack in pairs(existing_packs) do
+			if key == value then
+				to_insert = false
+				break
+			end
+		end
+		if to_insert then
+			table.insert(technology.unit.ingredients, { value, 1 }) --Inserts science pack.
 		end
 	end
 end

--- a/prototypes/override-final/science.lua
+++ b/prototypes/override-final/science.lua
@@ -56,6 +56,10 @@ if data.raw["lab"]["lab"] then
 		data.raw["technology"]["promethium-science-pack"]["ensure_all_packs_from_vanilla_lab"] = true
 	end
 
+	if data.raw["technology"]["research-productivity"] then
+		data.raw["technology"]["research-productivity"]["ensure_all_packs_from_vanilla_lab"] = true
+	end
+
 	for _, value in pairs(data.raw["technology"]) do
 		if value["ensure_all_packs_from_vanilla_lab"] and value["ensure_all_packs_from_vanilla_lab"] == true then
 			tech.set_science_packs_from_lab(value, vanilla_lab)


### PR DESCRIPTION
Addressing https://github.com/danielmartin0/PlanetsLib/issues/34.

When a technology is declared an endgame technology, but that technology unlocks a science pack recipe, that pack will no longer be required by the technology.

Also declares "research-productivity" to be an endgame technology.