### PR TITLE
Making it easier to integrate PlanetsLib into existing planets with vanilla-style orbit information

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 1.2.7
 Date: ????
   Changes:
+    - Planets with vanilla-style orbit fields can now be passed to PlanetsLib:extend without crashing. 
 ---------------------------------------------------------------------------------------------------
 Version: 1.2.6
 Date: 2025-02-07


### PR DESCRIPTION
I have added an additional step to PlanetsLib:extend that reduces the amount of work needed to integrate a planet into PlanetsLib. In the current version of PlanetsLib, all PlanetsLib planets must have a fully defined orbit field, so this change will not break compatibility with any planets currently using PlanetsLib.

If config.distance and config.orientation exist, but config.orbit is undefined, this code concludes that its orbit should go around the sun like all non-PlanetsLib planets, and generates an orbit field with that assumption, deleting config.distance and config.orientation.

This change will make it easier to integrate PlanetsLib into existing planets by eliminating the need to learn how the orbit field must be defined. With this change, only bodies that have an unusual orbit will need to have a fully-defined orbit according to PlanetsLib conventions.