### PR TITLE
Making technology_icon_planet and technology_icon_moon more compliant with API changes

### DIFF
--- a/lib/technology.lua
+++ b/lib/technology.lua
@@ -65,40 +65,50 @@ function Public.technology_effect_cargo_drops(planet_name)
 	}
 end
 
+
 function Public.technology_icon_moon(moon_icon, icon_size)
 	icon_size = icon_size or 256
-
-	local icons = {
-		{
-			icon = moon_icon,
-			icon_size = icon_size,
-		},
-		{
-			icon = "__PlanetsLib__/graphics/icons/moon-technology-symbol.png",
-			icon_size = 128,
-			scale = 0.5,
-			shift = { 50, 50 },
-		},
-	}
+	local icons = util.technology_icon_constant_planet(moon_icon)
+	icons[1].icon_size = icon_size
+	icons[2].icon = "__PlanetsLib__/graphics/icons/moon-technology-symbol.png"
+	-- End result is an icons object ressembling the following, as of 2.0.37. Future API changes might change this code,
+	-- which is why this function is written to reference the base function instead of copying it by hand.
+	-- local icons = {
+	-- 	{
+	-- 		icon = moon_icon,
+	-- 		icon_size = icon_size,
+	-- 	},
+	-- 	{
+	-- 		icon = "__PlanetsLib__/graphics/icons/moon-technology-symbol.png",
+	-- 		icon_size = 128,
+	-- 		scale = 0.5,
+	-- 		shift = { 50, 50 },
+	-- 		floating = true
+	-- 	},
+	-- }
 	return icons
 end
 
 -- The same as util.technology_icon_constant_planet from the vanilla library, but allows any icon size.
 function Public.technology_icon_planet(planet_icon, icon_size)
 	icon_size = icon_size or 256
-
-	local icons = {
-		{
-			icon = planet_icon,
-			icon_size = icon_size,
-		},
-		{
-			icon = "__core__/graphics/icons/technology/constants/constant-planet.png",
-			icon_size = 128,
-			scale = 0.5,
-			shift = { 50, 50 },
-		},
-	}
+	local icons = util.technology_icon_constant_planet(planet_icon)
+	icons[1].icon_size = icon_size
+	-- End result is an icons object ressembling the following, as of 2.0.37. Future API changes might change this code,
+	-- which is why this function is written to reference the base function instead of copying it by hand.
+	-- local icons = {
+	-- 	{
+	-- 		icon = planet_icon,
+	-- 		icon_size = icon_size,
+	-- 	},
+	-- 	{
+	-- 		icon = "__core__/graphics/icons/technology/constants/constant-planet.png",
+	-- 		icon_size = 128,
+	-- 		scale = 0.5,
+	-- 		shift = { 50, 50 },
+	-- 		floating = true
+	-- 	},
+	-- }
 	return icons
 end
 


### PR DESCRIPTION
In this PR, the functions technology_icon_planet and technology_icon_moon will now run the util function they are emulating, then apply changes to icon size and graphics as desired, instead of manually copying that util function. This change will make these functions more compliant with future API changes. If the util function changes to accomodate a new API feature, these changes will now propagate to PlanetsLib's functions.

This PR was made to add 2.0.34's "floating = true" field to these functions, but it has been rewritten to be more general.

This PR should work on both stable (2.0.32) and experimental(2.0.37).