### PR TITLE
compat: Added incompatibility tag to MT-lib

### DIFF
--- a/info.json
+++ b/info.json
@@ -6,5 +6,5 @@
     "author": "thesixthroc",
     "description": "Code, graphics and conventions to help modders creating planets, moons and other systems. This is a community project.",
     "homepage": "https://github.com/danielmartin0/PlanetsLib",
-    "dependencies": ["base >= 2.0.0", "space-age >= 2.0.0", "(?) Cosmic-Social-Distancing >= 1.0.2"]
+    "dependencies": ["base >= 2.0.0", "space-age >= 2.0.0", "(?) Cosmic-Social-Distancing >= 1.0.2", "! MT-lib"]
 }


### PR DESCRIPTION
We should mark MT-Lib as incompatible with PlanetsLib. Since some code in PlanetsLib was copied from and uses the same namespace as MT-Lib, they do not work well with each other. Loading Muluna and burner-everything(The only mod that requires MT-Lib) causes the game to hang while loading data-final-fixes of MT-Lib-ex(A dependency of MT-Lib). The same occurs when loading Cerys and burner-everything. I just received a PR to remove Muluna's incompatibility tag with PlanetsLib, which I'm not going to do. We should do more to discourage people from issuing similar PRs.