### PR TITLE
Extended PlanetsLib.borrow_music to allow cloning music to/from space-platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Subgroups are rows in Factoriopedia.
 * `PlanetsLib.technology_icon_moon` — Creates a moon discovery technology icon.
 * `PlanetsLib.technology_icon_planet` — Creates a planet discovery technology icon.
 * `PlanetsLib.set_default_import_location(item_name, planet_name)` — Sets the default import location for an item on a planet.
-* `PlanetsLib.borrow_music(source_planet, target_planet)` — Clones music tracks from `source_planet` prototype to `target_planet` prototype. Does not overwrite existing music for `target_planet`.
+* `PlanetsLib.borrow_music(source_planet, target_planet)` — Clones music tracks from `source_planet` prototype to `target_planet` prototype. Does not overwrite existing music for `target_planet`. To clone music from or to space platforms, set the respective parameter to "space-platform." Otherwise, use the relevant planet object.
 
 #### Assorted graphics
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 Version: 1.2.17
 Date: ????
   Changes:
-    - Modified PlanetsLib.borrow_music() to allow the copying of music from "space-platform" using the syntax 'PlanetsLib.borrow_music("space-platform", [target_planet]).'
+    - Modified PlanetsLib.borrow_music() to allow the copying of music to/from "space-platform."
 ---------------------------------------------------------------------------------------------------
 Version: 1.2.16
 Date: 2025-03-18

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 Version: 1.2.17
 Date: ????
   Changes:
+    - Modified PlanetsLib.borrow_music() to allow the copying of music from "space-platform" using the syntax 'PlanetsLib.borrow_music("space-platform", [target_planet]).'
 ---------------------------------------------------------------------------------------------------
 Version: 1.2.16
 Date: 2025-03-18

--- a/lib/planet.lua
+++ b/lib/planet.lua
@@ -36,6 +36,12 @@ function Public.is_space_location(planet)
 	return planet.type == "planet" or planet.type == "space-location"
 end
 
+function Public.is_space_location_or_space_platform(planet)
+	if not planet then
+		return false
+	end
+	return planet == "space-platform" or planet.type == "planet" or planet.type == "space-location"
+end
 -- TODO: Add checks to ensure the structure of orbit is correct.
 function Public.verify_extend_fields(config)
 	if not Public.is_space_location(config) then
@@ -122,20 +128,28 @@ function Public.verify_update_fields(config)
 	end
 end
 
+
+
 --- Clones music tracks from source_planet to target_planet.
 --- Does not overwrite existing music for target_planet.
 function Public.borrow_music(source_planet, target_planet)
 	assert(
-		Public.is_space_location(source_planet),
-		"PlanetsLib.borrow_music() - Invalid parameter 'source_planet'. Field is required to be either `space-location` or `planet` prototype."
+		Public.is_space_location_or_space_platform(source_planet),
+		"PlanetsLib.borrow_music() - Invalid parameter 'source_planet'. Field is required to be either `space-platform` or a `space-location` or `planet` prototype."
 	)
 	assert(
-		Public.is_space_location(target_planet),
-		"PlanetsLib.borrow_music() - Invalid parameter 'target_planet'. Field is required to be either `space-location` or `planet` prototype."
+		Public.is_space_location_or_space_platform(target_planet),
+		"PlanetsLib.borrow_music() - Invalid parameter 'target_planet'. Field is required to be either `space-platform` or a `space-location` or `planet` prototype."
 	)
 
+	local source_name = source_planet.name or source_planet
+
+	if source_name == "space-platform" then
+		source_name = nil
+	end
+
 	for _, music in pairs(util.table.deepcopy(data.raw["ambient-sound"])) do
-		if music.planet == source_planet.name then
+		if music.planet == source_name then
 			music.name = music.name .. "-" .. target_planet.name
 			music.planet = target_planet.name
 			data:extend({ music })

--- a/lib/planet.lua
+++ b/lib/planet.lua
@@ -144,14 +144,19 @@ function Public.borrow_music(source_planet, target_planet)
 
 	local source_name = source_planet.name or source_planet
 
+	local target_name = target_planet.name
 	if source_name == "space-platform" then
 		source_name = nil
 	end
 
+	if target_name == "space-platform" then
+		target_name  = nil
+	end
+
 	for _, music in pairs(util.table.deepcopy(data.raw["ambient-sound"])) do
 		if music.planet == source_name then
-			music.name = music.name .. "-" .. target_planet.name
-			music.planet = target_planet.name
+			music.name = music.name .. "-" .. target_name
+			music.planet = target_name
 			data:extend({ music })
 		end
 	end


### PR DESCRIPTION
This PR makes it possible to copy music to/from space-platform, which is the only space location in space age that is not technically one planet.

## Example usage
```
PlanetsLib.borrow_music("space-platform", data.raw["planet"]["muluna"]) --Copy from "space-platform" to Muluna
PlanetsLib.borrow_music(data.raw["planet"]["nauvis"], "space-platform") --Copy from Nauvis to "space-platform"
```
