### PR TITLE
Rocket part interface(>=2.0.58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ You can use the library to restrict cargo drops on your planet until a certain t
     * A locale entry for this technology is automatically generated, but you are free to override it.
 * Note that players can use [this mod](https://mods.factorio.com/mod/disable-cargo-drops-techs) to disable the effect of this restriction.
 
+## Rocket part recipes
+
+You can use the library to assign unique rocket part recipes to rocket silos placed on a planet. Rocket silos with their recipe defaulting to the vanilla `rocket-part` recipe are targeted by  PlanetsLib. To implement:
+
+* Use the helper function `PlanetsLib.assign_rocket_part_recipe(planet,recipe)` to assign a recipe to a planet.
+    * PlanetsLib stores rocket part recipe assignments in a mod-data prototype named `Planetslib-planet-rocket-part-recipe`. Planets with their own system for assigning rocket part recipes are exempted with the assigned recipe name `_other`. Muluna and Maraxsis are currently exempted in this manner to maintain backwards compatibility with those mods.
+    * Planets without an assigned recipe default to the vanilla `rocket-part` recipe.
+
 ## Surface conditions
 
 #### New surface conditions

--- a/api.lua
+++ b/api.lua
@@ -5,6 +5,7 @@ local planet = require("lib.planet")
 local planet_str = require("lib.planet-str")
 local surface_conditions = require("lib.surface_conditions")
 local tiers = require("tiers")
+local mod_data = require("lib.mod-data")
 
 --== APIs ==--
 -- API documentation lives in README.md (or on the mod portal.)
@@ -19,6 +20,8 @@ PlanetsLib.excise_effect_from_tech_tree = technology.excise_effect_from_tech_tre
 PlanetsLib.technology_icon_moon = technology.technology_icon_moon
 PlanetsLib.technology_icon_planet = technology.technology_icon_planet
 PlanetsLib.cargo_drops_technology_base = technology.cargo_drops_technology_base
+
+PlanetsLib.assign_rocket_part_recipe = mod_data.assign_rocket_part_recipe
 
 PlanetsLib.get_planet_tier = tiers.get_planet_tier
 PlanetsLib.get_space_location_tier = tiers.get_space_location_tier

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 ---------------------------------------------------------------------------------------------------
-Version: 1.6.3
+Version: 1.7.0
 Date: ????
   Changes:
+    - Added unified interface allowing planets to define rocket silo recipes on a per-surface basis.
 ---------------------------------------------------------------------------------------------------
 Version: 1.6.2
 Date: 2025-06-16

--- a/control.lua
+++ b/control.lua
@@ -1,3 +1,9 @@
 if script.active_mods["space-age"] then
 	require("scripts.cargo-pods")
 end
+
+local rocket_parts = require("scripts.rocket-parts")
+
+script.on_event(defines.events.on_built_entity, function(event)
+    rocket_parts.on_built_rocket_silo(event)
+end)

--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,3 +1,4 @@
 if mods["space-age"] then
 	require("prototypes.override.add-missing-orbit-fields")
+	require("prototypes.override.rocket-silos")
 end

--- a/data.lua
+++ b/data.lua
@@ -6,4 +6,5 @@ if mods["space-age"] then
 	require("prototypes.surface-property")
 	require("prototypes.categories")
 	require("prototypes.star")
+	require("prototypes.mod-data")
 end

--- a/info.json
+++ b/info.json
@@ -7,8 +7,8 @@
     "description": "Code, graphics and conventions to help modders creating planets, moons and other systems. This is a community project.",
     "homepage": "https://github.com/danielmartin0/PlanetsLib",
     "dependencies": [
-        "base >= 2.0.0",
-        "? space-age >= 2.0.0",
+        "base >= 2.0.58",
+        "? space-age >= 2.0.58",
         "(?) Cosmic-Social-Distancing >= 1.0.2",
         "! MT-lib"
     ]

--- a/lib/mod-data.lua
+++ b/lib/mod-data.lua
@@ -1,0 +1,22 @@
+local Public = {}
+
+function Public.assign_rocket_part_recipe(planet,recipe) 
+    local planet_name
+    local recipe_name
+    if type(planet) == "list" then
+        planet_name = planet.name
+    else
+        planet_name = planet
+    end
+    if type(recipe) == "list" then
+        recipe_name = recipe.name
+    else
+        recipe_name = recipe
+    end
+    data.raw["mod-data"]["Planetslib-planet-rocket-part-recipe"].data[planet_name] = recipe_name
+
+end
+
+
+
+return Public

--- a/prototypes/mod-data.lua
+++ b/prototypes/mod-data.lua
@@ -1,0 +1,21 @@
+--Custom mod data for control stage
+
+local rocket_part_recipe_data = {
+    type = "mod-data",
+    name = "Planetslib-planet-rocket-part-recipe",
+    data_type = "recipe",
+    data = {
+        default = "rocket-part", --Used for surfaces not specified.
+    }
+}
+
+data:extend{rocket_part_recipe_data}
+local blacklisted_planets = { --Planets with their own system for replacing rocket part recipes.
+    "muluna",
+    "maraxsis",
+}
+for _,planet in pairs(blacklisted_planets) do
+    PlanetsLib.assign_rocket_part_recipe(planet,"_other")
+end
+-- For other mods, data.raw["mod-data"]["Planetslib-rocket-part-recipe"].data["muluna"] = "rocket-part-muluna"
+

--- a/prototypes/override/rocket-silos.lua
+++ b/prototypes/override/rocket-silos.lua
@@ -1,0 +1,6 @@
+for _, silo in pairs(data.raw["rocket-silo"]) do
+    if silo.fixed_recipe == "rocket-part" then
+        silo.fixed_recipe = nil
+        silo.disabled_when_recipe_not_researched = true
+    end
+end

--- a/scripts/rocket-parts.lua
+++ b/scripts/rocket-parts.lua
@@ -1,0 +1,29 @@
+local Public = {}
+function Public.on_built_rocket_silo(event)
+    local entity = event.entity
+    if not entity.valid then return end
+    
+    local prototype = entity.name == "entity-ghost" and entity.ghost_prototype or entity.prototype
+    
+    if prototype.type ~= "rocket-silo" then return end
+    if not prototype.crafting_categories["rocket-building"] then return end
+    local rocket_part_recipe_data = prototypes.mod_data["Planetslib-planet-rocket-part-recipe"].data
+    local recipe
+    if rocket_part_recipe_data[entity.surface.name] then
+        recipe = rocket_part_recipe_data[entity.surface.name]
+    else 
+        recipe = rocket_part_recipe_data["default"]
+    end
+    
+
+    if recipe == "_other" then return end --If planet excluded from planetlib script, do nothing, let other planet mod handle rocket part recipe assignment.
+
+    entity.set_recipe(recipe)
+
+end
+
+
+--Based on code from Maraxsis' project-seadragon, but altered to be more general using 2.0.58's mod-data prototype 
+
+return Public
+


### PR DESCRIPTION
This feature requires Factorio 2.0.58, which is currently experimental. This system is backwards compatible with mods that use a similar system to assign custom rocket part recipes, like Maraxsis and Muluna. If there are other planet mods that use a similar system, they should be exempted as well.

## Rocket part recipes

You can use the library to assign unique rocket part recipes to rocket silos placed on a planet. Rocket silos with their recipe defaulting to the vanilla `rocket-part` recipe are targeted by  PlanetsLib. To implement:

* Use the helper function `PlanetsLib.assign_rocket_part_recipe(planet,recipe)` to assign a recipe to a planet.
    * PlanetsLib stores rocket part recipe assignments in a mod-data prototype named `Planetslib-planet-rocket-part-recipe`. Planets with their own system for assigning rocket part recipes are exempted with the assigned recipe name `_other`. Muluna and Maraxsis are currently exempted in this manner to maintain backwards compatibility with those mods.
    * Planets without an assigned recipe default to the vanilla `rocket-part` recipe.

