### PR TITLE
fix: Rocket silo recipe locked after receiving special rocket part recipe

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 ---------------------------------------------------------------------------------------------------
 Version: 1.8.3
 Date: ????
-  Changes:
+  Bugfixes:
+    - Rocket silos locked after being set to a PlanetsLib-designated rocket part recipe.
 ---------------------------------------------------------------------------------------------------
 Version: 1.8.2
 Date: 2025-07-20

--- a/scripts/rocket-parts.lua
+++ b/scripts/rocket-parts.lua
@@ -19,6 +19,7 @@ function Public.on_built_rocket_silo(event)
     if recipe == "_other" then return end --If planet excluded from planetlib script, do nothing, let other planet mod handle rocket part recipe assignment.
 
     entity.set_recipe(recipe)
+    entity.recipe_locked = true
 
 end
 


### PR DESCRIPTION
This PR fixes an issue in PlanetsLib's rocket-part code where rocket silos' recipes are not locked after getting assigned a recipe by PlanetsLib.