### PR TITLE
Various Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,12 @@ The arguments are: distance, the name of the planet then the name of the mod. Th
 Eg: `sh generate-orbit.sh 10 vulcanus Planetslib`
 
 On Windows, this script can run with Git Bash. An untested equivalent Powershell script is also included.
+On Linux, this may help:
+  Get python3 on "Software Manager" or equivelent
+  sudo apt install python3-pip
+  sudo apt install python3-numpy
+  sudo apt install python3-matplotlib
+  python3 generate_orbit_graphics.py 10 vulcanus Planetslib
 
 
 [![Discord](https://img.shields.io/discord/1309620686347702372?style=for-the-badge&logoColor=bf6434&label=The%20Foundry&labelColor=222222&color=bf6434)](https://foundrygg.com)

--- a/generate_orbit_graphics.py
+++ b/generate_orbit_graphics.py
@@ -5,7 +5,7 @@ import argparse
 # Instantiate the parser
 parser = argparse.ArgumentParser(prog=os.getenv('PROGRAM_NAME'))
 
-parser.add_argument('distance', type=int,
+parser.add_argument('distance', type=float,
                     help='distance from the parent')
 
 parser.add_argument('planet_name', type=ascii,

--- a/lib/orbit_graphic_generator.py
+++ b/lib/orbit_graphic_generator.py
@@ -28,13 +28,13 @@ def generate_orbit(distance, output_file, mod_name):
     factorio_texture_size_limit=4096
 
     width=1
-    resolution=512*distance
+    thickness = 3
 
-    radius=distance*64
+    resolution=512*distance+thickness*2
+
+    radius=distance*64+thickness
 
     scale_modifier = 1 
-    
-    thickness = 3
 
     if resolution > factorio_texture_size_limit:
         scale_modifier = factorio_texture_size_limit / resolution 
@@ -80,6 +80,13 @@ def generate_orbit(distance, output_file, mod_name):
     plt.savefig(output_file, bbox_inches="tight",pad_inches=0, dpi=resolution,transparent=True)
     plt.close()
 
+    with open(output_file + ".txt", "w") as orbitcode:
+        orbitcode.write("""sprite = {{
+            type = "sprite",
+            filename = "__{}__/graphics/orbits/{}",
+            size = {},
+            scale = {},
+        }}""".format(mod_name,output_file,math.floor(resolution_old*(1+width)/2), 0.25/scale_modifier))
 
     print(f"Orbit sprite saved to {os.path.abspath(output_file)}\n")
     print(f"Add this to the 'orbit' field of your planet definition:\n")


### PR DESCRIPTION
- Small amount of documentation of getting the python script working on Linux
- Orbit Generating Python Script no longer generates images just too small for the actual orbits because of line thickness (minor quality enhancement)
- Orbit generating Python Script now exports .lua code it prints into terminal into a txt that is the orbit image file + .txt
- Python Script now accepts float rather than just integers on orbital distances for more versatility