### PR TITLE
rocket-parts changes only applies to recipes defined within planet lib

### DIFF
--- a/scripts/rocket-parts.lua
+++ b/scripts/rocket-parts.lua
@@ -20,25 +20,16 @@ function Public.on_built_rocket_silo(event)
     local rocket_part_recipe_data = prototypes.mod_data["Planetslib-planet-rocket-part-recipe"].data
     local lock_rocket_silo_data = prototypes.mod_data["Planetslib-planet-lock-rocket-silos"].data
     local recipe, lock_silo
+
     if rocket_part_recipe_data[entity.surface.name] then
         recipe = rocket_part_recipe_data[entity.surface.name]
-    else 
-        recipe = rocket_part_recipe_data["default"]
-    end
-
-    if lock_rocket_silo_data[entity.surface.name] then
         lock_silo = lock_rocket_silo_data[entity.surface.name]
-    else 
         lock_silo = lock_rocket_silo_data["default"]
+        entity.set_recipe(recipe)
+        entity.recipe_locked = lock_silo
     end
-    
 
-    if recipe == "_other" then return end --If planet excluded from planetlib script, do nothing, let other planet mod handle rocket part recipe assignment.
-
-    entity.set_recipe(recipe)
-    entity.recipe_locked = lock_silo
 end
-
 
 --Based on code from Maraxsis' project-seadragon, but altered to be more general using 2.0.58's mod-data prototype 
 


### PR DESCRIPTION
moves setting and locking silo into singe conditional
it should work like before for every planet that follow planet lib

this piece of code is not needed anymore because if we don't force default recipe we don't need exceptions
```
if recipe == "_other" then return end --If planet excluded from planetlib script, do nothing, let other planet mod handle rocket part recipe assignment.
```