### PR TITLE
Fix science pack sort crash; improve recipe freshness tooltips

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,9 @@ Version: 1.19.3
 Date: ???
   Changes:
     - Removed "Power required to heat up" tooltip, as it has been integrated into 2.1 vanilla.
+    - Changed "Freshness resets on craft beginning/completion" tooltips to specify which item(s) have their freshness reset.
+  Bugfixes:
+    - Fixed startup crash when a science pack prototype is an unexpected item sub-type.
 ---------------------------------------------------------------------------------------------------
 Version: 1.19.2
 Date: 2026-06-24

--- a/lib/technology.lua
+++ b/lib/technology.lua
@@ -304,7 +304,7 @@ end
 
 local function try_find_item_prototype_by_name(name)
 	for item_type in pairs(defines.prototypes.item) do
-		local proto = (data.raw[item_type])[name]
+		local proto = (data.raw[item_type] or {})[name]
 		if proto then
 			return proto
 		end

--- a/prototypes/override-final/enhanced-tooltips.lua
+++ b/prototypes/override-final/enhanced-tooltips.lua
@@ -15,13 +15,17 @@ local function assert_recipe_result_is_eligible(result)
 	return false
 end
 
-local function any_product_has(recipe, field)
+local function get_products_with(recipe, field)
+	local product_names
 	for _, result in pairs(recipe.results) do
-		if result[field] == true then
-			return true
+		if result.type == "item" and result[field] == true then
+			if not product_names then
+				product_names = {""}
+			end
+			table.insert(product_names, "[item="..result.name.."]")
 		end
 	end
-	return false
+	return product_names
 end
 
 if settings.startup["PlanetsLib-enhanced-tooltips"].value == true then
@@ -35,28 +39,21 @@ if settings.startup["PlanetsLib-enhanced-tooltips"].value == true then
 		then
 			local i = 200
 			for _, tooltip in ipairs({
-				{ "result-is-always-fresh", any_product_has(recipe, "always_fresh") },
-				{ "reset-freshness-on-craft", any_product_has(recipe, "reset_freshness_on_craft") },
-				{ "preserve-products-in-machine-output", recipe.preserve_products_in_machine_output == true },
+				{ "result-is-always-fresh", get_products_with(recipe, "always_fresh") },
+				{ "reset-freshness-on-craft", get_products_with(recipe, "reset_freshness_on_craft") },
+				{ "preserve-products-in-machine-output", recipe.preserve_products_in_machine_output and { "gui.yes" }},
 			}) do
-				if tooltip[2] then
+				if tooltip[2] and #tooltip[2] > 0 then
 					i = i + 1
 					local tooltip_field = {
 						name = { "tooltip." .. tooltip[1] },
-						value = { "gui.yes" },
+						value = tooltip[2],
 						order = i,
 					}
 					if not recipe.custom_tooltip_fields then
 						recipe.custom_tooltip_fields = {}
 					end
 					rro.soft_insert(recipe.custom_tooltip_fields, tooltip_field)
-					if data.raw["item"][recipe.name] then
-						local item = data.raw["item"][recipe.name]
-						if not item.custom_tooltip_fields then
-							item.custom_tooltip_fields = {}
-						end
-						rro.soft_insert(item.custom_tooltip_fields, tooltip_field)
-					end
 				end
 			end
 		end


### PR DESCRIPTION
## Description

- Fixed a [crash when sorting science packs](https://discord.com/channels/1309620686347702372/1407021435427225642/1519967192093954098).
- Updated "freshness" recipe tooltips to show the specific item(s) affected (freshness resetting on craft is now product-specific in 2.1).

## Checklist

- [ ] Changes have been tested
- [x] Changes do not break backwards compatibility
- [x] `changelog.txt` has been updated
- [ ] `README.md` has been updated (documentation section and/or Contributors list)

## Testing Notes

- So far just tested with vanilla recipes and Crucible recipes.

## Related Issues

[Bug report on discord](https://discord.com/channels/1309620686347702372/1407021435427225642/1519967192093954098).

## Screenshots

<img width="506" height="543" alt="Screenshot_20260626_163348" src="https://github.com/user-attachments/assets/d6b5ad85-e172-4017-9c68-77615d296293" /> <img width="520" height="529" alt="Screenshot_20260626_163120" src="https://github.com/user-attachments/assets/5b45899b-1a72-4970-af0c-f249b9b17207" /> <img width="421" height="715" alt="Screenshot_20260626_162934" src="https://github.com/user-attachments/assets/492ec7c3-f4bb-4248-98bb-b433ad61a633" />
