### PR TITLE
On rocket part crafted event

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -188,5 +188,27 @@ if is_entity_replacements then
 	--script.on_event(defines.events.on_player_setup_blueprint,entity_replacement.blueprint_standardize)
 end
 
+--On_crafted recipe handlers, the engine behind on_rocket_part_crafted
+for recipe_name,handle_table in pairs(PlanetsLib.constants.recipe_on_craft_event_handles) do
+	local recipe = prototypes.recipe[recipe_name]
+	local event_names = handle_table.raised_events_on_craft
+	assert(recipe.on_crafted_event,"Recipe on_crafted event handlers, but does not properly raise the events.")
+	
+		script.on_event(recipe.on_crafted_event,function(event)
+			for _,event_name in pairs(event_names) do
+				script.raise_event(event_name,event)
+			end
+			
+		
+		end)
+	
+end
+
+
+
+
 
 if script.active_mods["gvv"] then require("__gvv__.gvv")() end --gvv enables debugging of storage values with a GUI
+
+
+	

--- a/data.lua
+++ b/data.lua
@@ -35,7 +35,8 @@ data:extend({
 			},
 			planet_special_properties = { --Place to store arbitrary planet properties to avoid a proliferation of new mod-data objects.
 				--[planet name] = table {incl. rocket_lift_multiplier}
-			}
+			},
+			recipe_on_craft_event_handles = {},
 		},
 	},
 })

--- a/prototypes/events.lua
+++ b/prototypes/events.lua
@@ -3,5 +3,12 @@ data:extend{
         type = "custom-event",
         name = "PlanetsLib-on-entity-replaced"
         --Called when PlanetsLib replaces one entity with another.
-    }
+    },
 }
+if settings.startup["PlanetsLib-enable-on-rocket-part-crafted-event"].value then 
+    data:extend{{
+        type = "custom-event",
+        name = "PlanetsLib-on-rocket-part-crafted"
+        --Called when a rocket part is crafted.
+    }}
+end

--- a/scripts/custom-events.lua
+++ b/scripts/custom-events.lua
@@ -1,3 +1,10 @@
-return {
+local events = {
     on_entity_replaced = prototypes.custom_event["PlanetsLib-on-entity-replaced"]
+    
 }
+
+if settings.startup["PlanetsLib-enable-on-rocket-part-crafted-event"].value then 
+
+    events.on_rocket_part_crafted = prototypes.custom_event["PlanetsLib-on-rocket-part-crafted"]
+end
+return events

--- a/settings.lua
+++ b/settings.lua
@@ -121,5 +121,13 @@ data:extend({
 		forced_value = false,
 		default_value = false,
 		hidden = true,
+	},
+	{
+		type = "bool-setting",
+		setting_type = "startup",
+		name = "PlanetsLib-enable-on-rocket-part-crafted-event",
+		forced_value = false,
+		default_value = false,
+		hidden = true,
 	}
 })


### PR DESCRIPTION
## Description

This a a draft PR for a possible On_rocket_part_crafted event, called when any rocket part is crafted. This could be used by a modernized "Quality Rocket Parts" mod, or any other mod that modifies rocket part recipes in a strange way. https://github.com/nicholasgower/planet-muluna/issues/339 

I am making this draft PR to gauge interest in this feature.

## Checklist

- [ ] Changes have been tested
- [*] Changes do not break backwards compatibility
- [ ] `changelog.txt` has been updated
- [ ] `README.md` has been updated (documentation section and/or Contributors list)

## Testing Notes

This is currently untested, as while there is a system to set up events based on a mod-data list, the data-level helpers/loops to generate this list does not yet exist.

