### PR TITLE
Update productivity technology code to ignore invalid recipe results.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,9 @@
 ---------------------------------------------------------------------------------------------------
+Version: 1.23.4
+Date: 
+  Bugfixes:
+    - recipe productivity technology code no longer crashes the game if it found an invalid recipe result.
+---------------------------------------------------------------------------------------------------
 Version: 1.23.3
 Date: 2026-07-30
   Locale:

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "PlanetsLib",
-  "version": "1.23.3",
+  "version": "1.23.4",
   "factorio_version": "2.1",
   "title": "PlanetsLib",
   "author": "thesixthroc, MeteorSwarm",

--- a/lib/technology.lua
+++ b/lib/technology.lua
@@ -398,7 +398,8 @@ function Public.process_technology_recipe_productivity_effects(tech)
 			)
 		end
 
-		local category_blacklist = tech.PlanetsLib_recipe_productivity_effects.category_blacklist or { "recycling" } --Excluded recipe categories
+		local category_blacklist = tech.PlanetsLib_recipe_productivity_effects.category_blacklist or
+		{ "recycling" }                                                                                        --Excluded recipe categories
 
 		for _, recipe in pairs(data.raw["recipe"]) do
 			if not recipe.results then
@@ -419,7 +420,10 @@ function Public.process_technology_recipe_productivity_effects(tech)
 					not result.ignored_by_productivity
 					or result.ignored_by_productivity < (result.amount or result.amount_max)
 				then
-					net_results[result.name] = result.type --Count multiple results with the same same name as a single result
+					if result.name and result.type then
+						--Count multiple results with the same same name as a single result
+						net_results[result.name] = result.type
+					end
 				end
 			end
 			local results_count = table_size(net_results)


### PR DESCRIPTION
## Description

The code creating recipe productivity technologies can crash if the result is not defined properly, and it hides the error from the developer.

## Checklist

- [X] Changes have been tested
- [X] Changes do not break backwards compatibility
- [X] `changelog.txt` has been updated
- [X] `README.md` has been updated (documentation section and/or Contributors list)

## Testing Notes

Tested with the outer rim plus a mod that had an invalid recipe (name field not defined properly).

